### PR TITLE
feat: today's driver locations, GET API, and seeded demo GPS (#8)

### DIFF
--- a/delivery-api/src/main/java/com/deliverysystem/config/DataSeeder.java
+++ b/delivery-api/src/main/java/com/deliverysystem/config/DataSeeder.java
@@ -16,11 +16,15 @@ import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 @Configuration
 public class DataSeeder {
@@ -31,6 +35,7 @@ public class DataSeeder {
     private boolean seedEnabled;
     
     @Bean
+    @org.springframework.core.annotation.Order(1)
     public CommandLineRunner seedData(
             DepotRepository depotRepository,
             RouteRepository routeRepository,
@@ -81,7 +86,61 @@ public class DataSeeder {
             });
         };
     }
-    
+
+    /**
+     * Inserts a small polyline of GPS samples for {@code driver1} on the current UTC calendar day when none
+     * exist yet, so the driver-locations dashboard has demo data without calling the mobile ingest API.
+     * Runs even when the main seed is skipped (existing database).
+     */
+    @Bean
+    @org.springframework.core.annotation.Order(2)
+    public CommandLineRunner seedDriverLocationDemoForToday(
+            @Value("${application.seed.enabled:true}") boolean seedEnabled,
+            UserRepository userRepository,
+            DriverLocationSampleRepository driverLocationSampleRepository) {
+        return args -> {
+            if (!seedEnabled) {
+                return;
+            }
+            Optional<User> driverOpt = userRepository.findByUsername("driver1");
+            if (driverOpt.isEmpty()) {
+                return;
+            }
+            User driver = driverOpt.get();
+            LocalDate todayUtc = LocalDate.now(ZoneOffset.UTC);
+            Instant dayStart = todayUtc.atStartOfDay(ZoneOffset.UTC).toInstant();
+            Instant dayEnd = todayUtc.plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant();
+            if (driverLocationSampleRepository.countByUser_IdAndRecordedAtGreaterThanEqualAndRecordedAtLessThan(
+                    driver.getId(), dayStart, dayEnd) > 0) {
+                return;
+            }
+
+            // Short path near central London; recordedAt spread across the UTC day for a visible trace + table
+            double[][] latLon = {
+                {51.50740, -0.12780},
+                {51.50785, -0.12835},
+                {51.50825, -0.12895},
+                {51.50870, -0.12955},
+                {51.50910, -0.13015},
+                {51.50955, -0.13075},
+                {51.51000, -0.13135},
+            };
+            Instant received = Instant.now();
+            List<DriverLocationSample> batch = new ArrayList<>(latLon.length);
+            for (int i = 0; i < latLon.length; i++) {
+                DriverLocationSample row = new DriverLocationSample();
+                row.setUser(driver);
+                row.setLatitude(BigDecimal.valueOf(latLon[i][0]));
+                row.setLongitude(BigDecimal.valueOf(latLon[i][1]));
+                row.setRecordedAt(dayStart.plus(8, ChronoUnit.HOURS).plus(i * 75L, ChronoUnit.MINUTES));
+                row.setReceivedAt(received);
+                batch.add(row);
+            }
+            driverLocationSampleRepository.saveAll(batch);
+            log.info("Seeded {} demo driver location samples for driver1 on {} (UTC)", batch.size(), todayUtc);
+        };
+    }
+
     private void seedAllData(
             DepotRepository depotRepository,
             RouteRepository routeRepository,

--- a/delivery-api/src/main/java/com/deliverysystem/repository/DriverLocationSampleRepository.java
+++ b/delivery-api/src/main/java/com/deliverysystem/repository/DriverLocationSampleRepository.java
@@ -12,4 +12,9 @@ public interface DriverLocationSampleRepository extends JpaRepository<DriverLoca
         String userId,
         Instant startInclusive,
         Instant endExclusive);
+
+    long countByUser_IdAndRecordedAtGreaterThanEqualAndRecordedAtLessThan(
+        String userId,
+        Instant startInclusive,
+        Instant endExclusive);
 }


### PR DESCRIPTION
## Summary
Delivers [issue #8](https://github.com/nichom01/delivery/issues/8): depot **Driver locations** page with graphic vs raw data, **`GET /api/v1/driver-locations`** (UTC day filter, role-scoped access), Flyway index, integration tests, and **demo seed data** for `driver1` on the current UTC day when the table is empty for that day.

Also includes **`POST /api/v1/driver-locations`** (driver ingest) from the prerequisite branch if not yet on `main`.

## Seed / demo
When `application.seed.enabled` is true, after the main seed a runner inserts **7** London-area points for **Alex Driver** (`driver1`) for **today (UTC)** if none exist yet—so the dashboard has data without curl.

Closes #8